### PR TITLE
teardown docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,24 @@
 # appy-reviews
 
-A "smart" Web application for reviewing DSSG program application submissions
+Appy is a "smart" Web application for reviewing DSSG program application submissions.
 
 ## Management
 
-### Requirements
+### Assumptions
 
-* docker
-* pyenv-virtualenv
+The below dependencies are not strict requirements, but they are strongly recommended and assumed.
+
+#### Docker
+
+Appy is developed against and deployed via [Docker](https://www.docker.com/).
+
+#### pyenv
+
+[pyenv](https://github.com/pyenv/pyenv) is a great development tool for managing versions of Python, as well as its plugin [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) for managing distinct virtual environments.
+
+#### direnv
+
+[direnv](https://direnv.net/) is another useful, generic development tool, for managing environmental variables.
 
 ### Set-up
 
@@ -19,7 +30,7 @@ A "smart" Web application for reviewing DSSG program application submissions
 
         pip install -r requirement/console.txt
 
-1. Optionally export environment variables:
+1. Optionally export environment variables such as:
 
     * `DATABASE_URL=postgres://appy_reviews:PASSWORD@DBHOST:DBPORT/appy_reviews`
     * `AWS_PROFILE`
@@ -30,3 +41,7 @@ A "smart" Web application for reviewing DSSG program application submissions
 Project development, deployment, _etc._ are managed via `argcmdr`:
 
     manage --help
+
+## Further reading
+
+Refer to the [documentation](doc/).

--- a/doc/infrastructure.adoc
+++ b/doc/infrastructure.adoc
@@ -1,0 +1,66 @@
+= Appy Infrastructure
+
+== Components
+
+* DNS (https://console.aws.amazon.com/route53/home[Route53])
+* Web Servers (https://console.aws.amazon.com/elasticbeanstalk/home[Elastic Beanstalk])
+** load balancer (https://console.aws.amazon.com/ec2/v2/home#LoadBalancers:sort=loadBalancerName[Elastic Load Balancer])
+** computational servers (https://console.aws.amazon.com/ec2/v2/home#Instances:sort=launchTime[EC2])
+* Database server (https://console.aws.amazon.com/rds/home[RDS])
+* Inactivity page (https://console.aws.amazon.com/s3/[S3] & https://console.aws.amazon.com/cloudfront/home[Cloudfront])
+
+== Shut it down
+
+Shut down Appy for the year.
+
+=== Update the static "closed" page in S3
+
+Review the http://review.dssg.io.s3-website-us-west-2.amazonaws.com/[Appy static site]. You can also review the https://s3-us-west-2.amazonaws.com/review.dssg.io/index.html["closed" page file directly].
+
+Note that the static site does **not** support HTTPS, (because it's an S3 Web site). This is why it is pushed to https://d2va83k0l3phq8.cloudfront.net/[Cloudfront], and DNS will be pointed to Cloudfront, instead.
+
+To update the "closed" page in S3:
+
+[source,sh]
+----
+manage static closed
+----
+
+The template behind this file can be found at:
+
+ src/review/templates/review/closed.html
+
+This template will automatically update the static page with the current year configured in settings.
+
+=== Point DNS at Cloudfront
+
+[NOTE]
+====
+The DNS configuration for `dssg.io` -- and `review.dssg.io` by extension -- historically resides under a different AWS account than the remainder of Appy's infrastructure.
+
+As these management commands wrap shell commands such as `aws`, you may pass necessary (novel) configuration via environment variable, such as:
+
+[source,sh]
+----
+AWS_PROFILE=dssg manage dns check
+----
+
+====
+
+To check the current DNS configuration for `review.dssg.io`:
+
+[source,sh]
+----
+manage dns check
+----
+
+The result should https://review.dssg.io/[reflect what you see] -- either the `LIVE` site or the `STATIC` site.
+
+To point the `review.dssg.io` domain at the Cloudfront site:
+
+[source,sh]
+----
+manage dns set static
+----
+
+DNS propagation may take some time. You can confirm the DNS configuration with the `manage dns check` command, (and furthermore with `dig`).

--- a/doc/infrastructure.adoc
+++ b/doc/infrastructure.adoc
@@ -1,4 +1,5 @@
 = Appy Infrastructure
+:toc:
 
 == Components
 
@@ -64,3 +65,83 @@ manage dns set static
 ----
 
 DNS propagation may take some time. You can confirm the DNS configuration with the `manage dns check` command, (and furthermore with `dig`).
+
+=== Terminate Web servers
+
+With `review.dssg.io` pointed at the static site, there's no need for the ELB nor EC2 instance(s).
+
+The Appy servers are managed by an Elastic Beanstalk environment.
+
+EB environments may not be simply "disabled." It is possible to simply scale down its instances; however, this leaves running an inactive load balancer.
+
+Instead, we'll cover saving its configuration and then terminating the environment.
+
+CAUTION: It **cannot** be guaranteed that the environment will rebuild precisely as it was. But, it should be reasonably close, and these commands may be refined for that purpose.
+
+==== Save environment configuration
+
+The following EB CLI command saves an environmental configuration both locally and in AWS:
+
+[source,sh]
+----
+eb config save appy-reviews-pro --cfg close_2019-04-24
+----
+
+In the above, we've saved the current configuration for environment `appy-reviews-pro` with the name `close_2019-04-24`.
+
+[NOTE]
+====
+The environment configuration _may_ (currently) contains **secrets**.
+
+As such, the project repository is configured to ignore these files. If you'd like to store this file elsewhere, consider Unix https://www.passwordstore.org/[`pass`].
+
+Regardless, AWS stores saved configurations. You may list these via the CLI:
+
+[source,sh]
+----
+eb config list
+----
+
+====
+
+==== Terminate environment
+
+Having saved the environment configuration, you may terminate the environment and its AWS resources:
+
+[source,sh]
+----
+eb terminate appy-reviews-pro
+----
+
+CAUTION: Do *not* supply to `terminate` the flag `--all`. This would remove the entire EB configuration for the appy-reviews application. (And though this would not be the end of the world, it's likely not what you want!)
+
+=== Terminate database
+
+First, note various RDS configuration options which are not persisted to the snapshot:
+
+Instance class::
+
+  `db.t2.medium`
+
+Parameter group::
+
+  `default.postgres10`
+
+Security groups::
+
+  * ddj compatible security group (`sg-5f596020`)
+  * rds-launch-wizard (`sg-05d804e82060e83d5`)
+
+Storage type::
+
+  General Purpose (SSD)
+
+Then, terminate the RDS database instance `appy`, ensuring that a final snapshot is taken:
+
+[source,sh]
+----
+aws rds delete-db-instance \
+    --db-instance-identifier appy  \
+    --final-db-snapshot-identifier appy-close-2019-04-24 \
+    --delete-automated-backups
+----


### PR DESCRIPTION
[review.dssg.io](https://review.dssg.io/) now points to the static closed page.

EC2, ELB & RDS are backed up and terminated.

Procedure documented (below).